### PR TITLE
Ws 6221/keep kafka connections warm

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,22 @@
+name: Pull Request
+on:
+  - pull_request
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Upgrade pip
+        run: |
+          python -m pip install --upgrade pip wheel
+      - name: Build wheel
+        run: |
+          export BOTO_CONFIG=/dev/null
+          python setup.py bdist_wheel

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Upgrade pip & wheel
         run: python -m pip install --upgrade pip wheel
       - name: Set wheel version
-        run: echo ::set-env name=KAFKA_PYTHON_VERSION::${GITHUB_REF#refs/*/}
+        run: echo "KAFKA_PYTHON_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Build wheel
         run: |
           export BOTO_CONFIG=/dev/null

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+name: Release
+on:
+  release:
+    types: [published]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Upgrade pip & wheel
+        run: python -m pip install --upgrade pip wheel
+      - name: Set wheel version
+        run: echo ::set-env name=KAFKA_PYTHON_VERSION::${GITHUB_REF#refs/*/}
+      - name: Build wheel
+        run: |
+          export BOTO_CONFIG=/dev/null
+          python setup.py bdist_wheel
+      - name: Publish wheels
+        uses: inmar/actions-dpn-python-publish@v1.0.0
+        with:
+          pypi_hostname: ${{ secrets.DPN_PYPI_HOSTNAME }}
+          pypi_username: ${{ secrets.DPN_PYPI_USERNAME }}
+          pypi_password: ${{ secrets.DPN_PYPI_PASSWORD }}

--- a/kafka/client_async.py
+++ b/kafka/client_async.py
@@ -157,10 +157,9 @@ class KafkaClient(object):
         keep_warm (int): The level of extra work to do to keep connections warm.
             0: Nothing extra. After bootstrapping, no extra connections will be
                 made, and idle connections will be closed.
-            1: In addition to (1), reopen idle connections after closing (after
-                connections_max_idle_ms)
-            2: After bootstrapping, connect to all leader brokers immediately
-                rather than waiting for first send.
+            1: Reopen idle connections after closing (after connections_max_idle_ms)
+            2: In addition to (1), after bootstrapping, connect to all leader brokers 
+                immediately rather than waiting for first send.
     """
 
     DEFAULT_CONFIG = {

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -284,10 +284,9 @@ class KafkaProducer(object):
         keep_warm (int): The level of extra work to do to keep connections warm.
             0: Nothing extra. After bootstrapping, no extra connections will be
                 made, and idle connections will be closed.
-            1: In addition to (1), reopen idle connections after closing (after
-                connections_max_idle_ms)
-            2: After bootstrapping, connect to all leader brokers immediately
-                rather than waiting for first send.
+            1: Reopen idle connections after closing (after connections_max_idle_ms)
+            2: In addition to (1), after bootstrapping, connect to all leader brokers 
+                immediately rather than waiting for first send.
 
     Note:
         Configuration parameters are described in more detail at

--- a/kafka/producer/kafka.py
+++ b/kafka/producer/kafka.py
@@ -281,6 +281,13 @@ class KafkaProducer(object):
         sasl_oauth_token_provider (AbstractTokenProvider): OAuthBearer token provider
             instance. (See kafka.oauth.abstract). Default: None
         kafka_client (callable): Custom class / callable for creating KafkaClient instances
+        keep_warm (int): The level of extra work to do to keep connections warm.
+            0: Nothing extra. After bootstrapping, no extra connections will be
+                made, and idle connections will be closed.
+            1: In addition to (1), reopen idle connections after closing (after
+                connections_max_idle_ms)
+            2: After bootstrapping, connect to all leader brokers immediately
+                rather than waiting for first send.
 
     Note:
         Configuration parameters are described in more detail at
@@ -335,6 +342,7 @@ class KafkaProducer(object):
         'sasl_kerberos_domain_name': None,
         'sasl_oauth_token_provider': None,
         'kafka_client': KafkaClient,
+        'keep_warm': 0,
     }
 
     _COMPRESSORS = {


### PR DESCRIPTION
In Web Services, we have encountered issues with very slow timeouts when sending to Kafka, especially on the first connection. The root cause is that the producer does not open a connection to broker nodes for sending until we attempt to send a message. To address this, we need to open connections on app startup (when we establish a connection to the bootstrap node(s) specified in settings). In addition, because we expect low throughput for campaign and segment updates, idle connection timeouts may also cause a new connection to be made on send. To avoid this, reconnect to the broker when the connection is closed after the idle timeout.

Changes to this library (we intend to submit a PR against the forked lib once these changes have been vetted):
- Add a new config option `keep_warm` to Kafka-python. When set to 0 (current default), nothing changes.
- Idle connections are closed after a configurable timeout. If `keep_warm` is set to 1 or greater, then the closed connection will be reopened.
- As part of initialization, it retrieves cluster metadata, including a list of all brokers. If `keep_warm` is set to 2 or greater, then establish connections with any nodes that do not have open connections.

Inmar-only changes:
- I added automation to send the library to our private PyPI server for use by other projects.